### PR TITLE
Update LayoutProcessor.java, Load only TrueTypeFontUnicode fonts

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/pdf/LayoutProcessor.java
+++ b/openpdf/src/main/java/com/lowagie/text/pdf/LayoutProcessor.java
@@ -270,6 +270,8 @@ public class LayoutProcessor {
 
     /**
      * Loads the AWT font needed for layout
+     * <p>
+     * If baseFont is not instanceof TrueTypeFontUnicode *no* font is loaded.
      *
      * @param baseFont OpenPdf base font
      * @param filename of the font file
@@ -279,7 +281,9 @@ public class LayoutProcessor {
         if (!enabled || awtFontMap.get(baseFont) != null) {
             return;
         }
-
+        if (!(baseFont instanceof TrueTypeFontUnicode)) {
+            return;
+        }
         java.awt.Font awtFont;
         InputStream inputStream = null;
         try {


### PR DESCRIPTION

## Description of the new Feature/Bugfix

Load only TrueTypeFontUnicode fonts

Related Issue:  See https://github.com/LibrePDF/OpenPDF/issues/1159

## Unit-Tests for the new Feature/Bugfix

--

## Compatibilities Issues
--

## Your real name
Volker Kunert

## Testing details

See  See https://github.com/LibrePDF/OpenPDF/issues/1159