### PR TITLE
Bugfix/properties of dc and pdf schemas for pdf a1 conformance

### DIFF
--- a/openpdf/src/main/java/com/lowagie/text/xml/xmp/DublinCoreSchema.java
+++ b/openpdf/src/main/java/com/lowagie/text/xml/xmp/DublinCoreSchema.java
@@ -49,7 +49,6 @@
 
 package com.lowagie.text.xml.xmp;
 
-
 import java.util.Arrays;
 
 /**
@@ -95,7 +94,7 @@ public class DublinCoreSchema extends XmpSchema {
      */
     public static final String IDENTIFIER = "dc:identifier";
     /**
-     * An unordered array specifying the languages used in the    resource.
+     * An unordered array specifying the languages used in the resource.
      */
     public static final String LANGUAGE = "dc:language";
     /**
@@ -129,32 +128,51 @@ public class DublinCoreSchema extends XmpSchema {
     public static final String TYPE = "dc:type";
     private static final long serialVersionUID = -4551741356374797330L;
 
-
     public DublinCoreSchema() {
         super("xmlns:" + DEFAULT_XPATH_ID + "=\"" + DEFAULT_XPATH_URI + "\"");
         setProperty(FORMAT, "application/pdf");
     }
 
     /**
-     * Adds a title.
+     * Adds a title for {@link LangAlt#DEFAULT default language}.
      *
      * @param title title
      */
     public void addTitle(String title) {
-        XmpArray array = new XmpArray(XmpArray.ALTERNATIVE);
-        array.add(title);
-        setProperty(TITLE, array);
+        addTitle(LangAlt.DEFAULT, title);
     }
 
     /**
-     * Adds a description.
+     * Adds a title for specified language.
+     *
+     * @param language language
+     * @param title    title
+     */
+    public void addTitle(String language, String title) {
+        LangAlt alt = new LangAlt();
+        alt.addLanguage(language, title);
+        setProperty(TITLE, alt);
+    }
+
+    /**
+     * Adds a description for {@link LangAlt#DEFAULT default language}.
      *
      * @param desc description
      */
     public void addDescription(String desc) {
-        XmpArray array = new XmpArray(XmpArray.ALTERNATIVE);
-        array.add(desc);
-        setProperty(DESCRIPTION, array);
+        addDescription(LangAlt.DEFAULT, desc);
+    }
+
+    /**
+     * Adds a description for specified language.
+     *
+     * @param language language
+     * @param desc     description
+     */
+    public void addDescription(String language, String desc) {
+        LangAlt alt = new LangAlt();
+        alt.addLanguage(language, desc);
+        setProperty(DESCRIPTION, alt);
     }
 
     /**
@@ -167,7 +185,6 @@ public class DublinCoreSchema extends XmpSchema {
         array.add(subject);
         setProperty(SUBJECT, array);
     }
-
 
     /**
      * Adds a subject.

--- a/openpdf/src/main/java/com/lowagie/text/xml/xmp/PdfSchema.java
+++ b/openpdf/src/main/java/com/lowagie/text/xml/xmp/PdfSchema.java
@@ -67,7 +67,7 @@ public class PdfSchema extends XmpSchema {
     /**
      * Keywords.
      */
-    public static final String KEYWORDS = "pdf:keywords";
+    public static final String KEYWORDS = "pdf:Keywords";
     /**
      * The PDF file version (for example: 1.0, 1.3, and so on).
      */
@@ -77,7 +77,6 @@ public class PdfSchema extends XmpSchema {
      */
     public static final String PRODUCER = "pdf:Producer";
     private static final long serialVersionUID = -1541148669123992185L;
-
 
     public PdfSchema() {
         super("xmlns:" + DEFAULT_XPATH_ID + "=\"" + DEFAULT_XPATH_URI + "\"");

--- a/openpdf/src/test/java/com/lowagie/text/pdf/fonts/FontTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/pdf/fonts/FontTest.java
@@ -37,7 +37,7 @@ class FontTest {
 
     private static final String FONT_NAME_WITHOUT_STYLES = "non-existing-font";
 
-    private static final String FONT_NAME_WITH_STYLES = "Courier";
+    private static final String FONT_NAME_WITH_STYLES = FontFactory.HELVETICA;
 
     private static final float DEFAULT_FONT_SIZE = 16.0f;
 

--- a/openpdf/src/test/java/com/lowagie/text/validation/PDFValidationTest.java
+++ b/openpdf/src/test/java/com/lowagie/text/validation/PDFValidationTest.java
@@ -4,6 +4,9 @@ import com.lowagie.text.Annotation;
 import com.lowagie.text.Document;
 import com.lowagie.text.PageSize;
 import com.lowagie.text.Rectangle;
+import com.lowagie.text.pdf.PdfDictionary;
+import com.lowagie.text.pdf.PdfName;
+import com.lowagie.text.pdf.PdfString;
 import com.lowagie.text.pdf.PdfWriter;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -24,11 +27,33 @@ import org.verapdf.pdfa.validation.validators.ValidatorFactory;
 public class PDFValidationTest {
 
     @Test
-    public void testValidatePDFWithVera() throws Exception {
+    public void testValidateDcTitleWithVera() throws Exception {
+        PdfDictionary info = new PdfDictionary(PdfName.METADATA);
+        info.put(PdfName.TITLE, new PdfString("Test pdf"));
+        Assertions.assertTrue(validatePDFWithVera(info));
+    }
+
+    @Test
+    public void testValidateDcDescriptionWithVera() throws Exception {
+        PdfDictionary info = new PdfDictionary(PdfName.METADATA);
+        // dc:description will be added (see constructor XmpWriter(OutputStream, PdfDictionary, int))
+        info.put(PdfName.SUBJECT, new PdfString("Test subject"));
+        Assertions.assertTrue(validatePDFWithVera(info));
+    }
+
+    @Test
+    public void testValidatePdfKeywordsWithVera() throws Exception {
+        PdfDictionary info = new PdfDictionary(PdfName.METADATA);
+        info.put(PdfName.KEYWORDS, new PdfString("k1, k2"));
+        Assertions.assertTrue(validatePDFWithVera(info));
+    }
+
+    private boolean validatePDFWithVera(PdfDictionary info) throws Exception {
         Document document = new Document(PageSize.A4);
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         PdfWriter pdfWriter = PdfWriter.getInstance(document, byteArrayOutputStream);
         pdfWriter.setPDFXConformance(PdfWriter.PDFA1B);
+        pdfWriter.getInfo().putAll(info);
         pdfWriter.createXmpMetadata();
 
         try {
@@ -56,12 +81,13 @@ public class PDFValidationTest {
                     for (TestAssertion assertion : result.getTestAssertions()) {
                         System.out.println(assertion);
                     }
-
                 }
-                Assertions.assertTrue(result.isCompliant());
+
+                return result.isCompliant();
             }
         } catch (ModelParsingException e) {
             e.printStackTrace();
+            return false;
         }
     }
 


### PR DESCRIPTION
## Description of the new Feature/Bugfix

To fix the bug, I improved multilingual support by refining the handling of language-alternative (`LangAlt`) title and description in the Dublin Core Schema using the standard-conforming syntax with the required (at least for PDF/A-1) `xml:lang` attribute. Further I fixed a typo in the `pdf:Keywords` tag in the PDF Schema.

## Unit-Tests for the new Feature/Bugfix

- [x] Unit-Tests added to reproduce the bug
- [x] Unit-Tests added to the added feature

## Compatibilities Issues

All existing methods behave as before. I only added two addtional methods for multilingual titles and descriptions. Even when using the existing API the output will slightly differ, because `xml:lang` is now always added to `dc:title` and `dc:description`.

## Your real name

Mikhail Stupnikov

## Testing details

I expanded `com.lowagie.text.validation.PDFValidationTest` to test the metadata fields in question.
I also changed the default font in `com.lowagie.text.pdf.fonts.FontTest` from Courier to Helvetica because of license problem for Courier on Mac OS. This test fails with Courier on Mac OS with message "DocumentException: Table 'OS/2' does not exist in /System/Library/Fonts/Courier.ttc". There are many discussions on Apple's official website. It seems Apple no longer supports this old font and did not renew the license. Anyway, which font is used does not matter for the mentioned test.